### PR TITLE
Update runInDocker.sh for Docker V2 compatability

### DIFF
--- a/runInDocker.sh
+++ b/runInDocker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Build And Run AICBot"
-docker-compose build --no-cache
-docker-compose up --detach --force-recreate
+docker compose build --no-cache
+docker compose up --detach --force-recreate


### PR DESCRIPTION
You can not build it with Docker V2 unless you fix Syntax.